### PR TITLE
Fix zedboard support

### DIFF
--- a/fpga/pulpissimo-zedboard/.gitignore
+++ b/fpga/pulpissimo-zedboard/.gitignore
@@ -20,3 +20,4 @@ gmon.out
 /pulpissimo-nexys_video/**/pulpissimo.bit
 
 **/xdc/constraints.xdc
+/pulpissimo-zedboard.gen/

--- a/fpga/pulpissimo-zedboard/fpga-settings.mk
+++ b/fpga/pulpissimo-zedboard/fpga-settings.mk
@@ -1,6 +1,6 @@
 export BOARD=zedboard
 export XILINX_PART=xc7z020clg484-1
-export XILINX_BOARD=em.avnet.com:zed:part0:1.4
+export XILINX_BOARD=avnet.com:zedboard:part0:1.4
 export FC_CLK_PERIOD_NS=62.5
 export PER_CLK_PERIOD_NS=100
 export SLOW_CLK_PERIOD_NS=30517

--- a/fpga/pulpissimo-zedboard/tcl/run.tcl
+++ b/fpga/pulpissimo-zedboard/tcl/run.tcl
@@ -50,10 +50,11 @@ set CLK_HALFPERIOD_NS [expr ${FC_CLK_PERIOD_NS} / 2.0]
 add_files -norecurse $FPGA_RTL/xilinx_pulpissimo.v
 
 # Add Xilinx IPs
-read_ip $FPGA_IPS/xilinx_clk_mngr/ip/xilinx_clk_mngr.xci
-read_ip $FPGA_IPS/xilinx_slow_clk_mngr/ip/xilinx_slow_clk_mngr.xci
-read_ip $FPGA_IPS/xilinx_interleaved_ram/ip/xilinx_interleaved_ram.xci
-read_ip $FPGA_IPS/xilinx_private_ram/ip/xilinx_private_ram.xci
+import_ip $FPGA_IPS/xilinx_clk_mngr/ip/xilinx_clk_mngr.xci
+import_ip $FPGA_IPS/xilinx_slow_clk_mngr/ip/xilinx_slow_clk_mngr.xci
+import_ip $FPGA_IPS/xilinx_interleaved_ram/ip/xilinx_interleaved_ram.xci
+import_ip $FPGA_IPS/xilinx_private_ram/ip/xilinx_private_ram.xci
+synth_ip [get_ips]
 
 # Add wrappers and xilinx specific techcells
 add_files -norecurse $FPGA_RTL/fpga_clk_gen.sv


### PR DESCRIPTION
This PR fixes the following error.

```
INFO: [Synth 8-6155] done synthesizing module 'pad_control' (0#1) [pulpissimo/rtl/pulpissimo/pad_control.sv:16]
INFO: [Synth 8-6157] synthesizing module 'fpga_slow_clk_gen' [pulpissimo/fpga/pulpissimo-zedboard/rtl/fpga_slow_clk_gen.sv:24]
ERROR: [Synth 8-439] module 'xilinx_slow_clk_mngr' not found [pulpissimo/fpga/pulpissimo-zedboard/rtl/fpga_slow_clk_gen.sv:48]
ERROR: [Synth 8-6156] failed synthesizing module 'fpga_slow_clk_gen' [pulpissimo/fpga/pulpissimo-zedboard/rtl/fpga_slow_clk_gen.sv:24]
ERROR: [Synth 8-6156] failed synthesizing module 'safe_domain' [pulpissimo/rtl/pulpissimo/safe_domain.sv:12]
ERROR: [Synth 8-6156] failed synthesizing module 'pulpissimo' [pulpissimo/rtl/pulpissimo/pulpissimo.sv:13]
ERROR: [Synth 8-6156] failed synthesizing module 'xilinx_pulpissimo' [pulpissimo/fpga/pulpissimo-zedboard/rtl/xilinx_pulpissimo.v:23]
```

## Note

`synth_ip` outputs the following message, but it's ignorable due to we are using non-project mode.

```
# synth_ip [get_ips]
CRITICAL WARNING: [Vivado 12-5447] synth_ip is not supported in project mode, please use non-project mode.
```
